### PR TITLE
Add entity hierarchy tree model with associations

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -4,7 +4,7 @@ class EntitiesController < ApplicationController
 
   # GET /entities or /entities.json
   def index
-    @entities = Entity.all
+    @entities = Entity.includes(:parent_entity).all
   end
 
   # GET /entities/1 or /entities/1.json

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,16 +1,42 @@
 class Entity < ApplicationRecord
+  belongs_to :parent_entity, class_name: "Entity", optional: true, foreign_key: :entity_id
+  has_many :sub_entities, class_name: "Entity", foreign_key: :entity_id, dependent: :nullify
+
   has_many :tasks
 
-  ENTITY_LEVELS = %w[LV BZV KV].freeze
+  ENTITY_LEVELS = %w[BV LV BZV KV].freeze
   ENTITY_LEVEL_LABELS = {
+    "BV" => "Bundesverband",
     "LV" => "Landesverband",
     "BZV" => "Bezirksverband",
     "KV" => "Kreisverband"
   }.freeze
 
   validates :entity_level, inclusion: { in: ENTITY_LEVELS }, allow_nil: true
+  validate :parent_is_not_self
+  validate :parent_is_not_descendant
 
   def entity_level_label
     ENTITY_LEVEL_LABELS[entity_level]
+  end
+
+  private
+
+  def parent_is_not_self
+    errors.add(:entity_id, "kann nicht auf sich selbst verweisen") if entity_id.present? && entity_id == id
+  end
+
+  def parent_is_not_descendant
+    return if entity_id.blank?
+    ancestor = Entity.find_by(id: entity_id)
+    visited = Set.new([ id ])
+    while ancestor
+      if visited.include?(ancestor.id)
+        errors.add(:entity_id, "würde einen Zirkelbezug erzeugen")
+        break
+      end
+      visited << ancestor.id
+      ancestor = Entity.find_by(id: ancestor.entity_id)
+    end
   end
 end

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -10,7 +10,7 @@
     <% if entity.entity_id.present? %>
       <div class="detail-item">
         <div class="detail-label">Übergeordnete Gliederung</div>
-        <div class="detail-value"><%= Entity.find_by(id: entity.entity_id)&.name || entity.entity_id %></div>
+        <div class="detail-value"><%= entity.parent_entity&.name || entity.entity_id %></div>
       </div>
     <% end %>
   </div>

--- a/app/views/entities/_entity.json.jbuilder
+++ b/app/views/entities/_entity.json.jbuilder
@@ -1,2 +1,3 @@
 json.extract! entity, :id, :name, :entity_level, :entity_id, :created_at, :updated_at
+json.parent_entity_name entity.parent_entity&.name
 json.url entity_url(entity, format: :json)

--- a/app/views/entities/index.html.erb
+++ b/app/views/entities/index.html.erb
@@ -21,7 +21,7 @@
       <tr>
         <td><%= link_to entity.name, entity %></td>
         <td><%= entity.entity_level_label %></td>
-        <td><%= Entity.find_by(id: entity.entity_id)&.name %></td>
+        <td><%= entity.parent_entity&.name %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -297,6 +297,7 @@ grant_type=client_credentials
   "entity_id": null,
   "created_at": "2025-01-01T00:00:00.000Z",
   "updated_at": "2025-01-01T00:00:00.000Z",
+  "parent_entity_name": null,
   "url": "https://meine-piraten.de/entities/1.json"
 }</code></pre>
 

--- a/db/migrate/20260319200001_add_entity_parent_foreign_key.rb
+++ b/db/migrate/20260319200001_add_entity_parent_foreign_key.rb
@@ -1,0 +1,6 @@
+class AddEntityParentForeignKey < ActiveRecord::Migration[8.1]
+  def change
+    add_index :entities, :entity_id
+    add_foreign_key :entities, :entities, column: :entity_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_19_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_19_200001) do
   create_table "admin_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "reason"

--- a/docs/API_OVERVIEW.md
+++ b/docs/API_OVERVIEW.md
@@ -265,6 +265,7 @@ An entity represents an organizational unit (e.g. Landesverband, Bezirksverband,
   "entity_id": 2,
   "created_at": "2025-04-04T14:07:33.000Z",
   "updated_at": "2025-04-04T14:07:33.000Z",
+  "parent_entity_name": "LV Hessen",
   "url": "https://meine-piraten.de/entities/1.json"
 }
 ```

--- a/test/fixtures/entities.yml
+++ b/test/fixtures/entities.yml
@@ -6,7 +6,7 @@ lv_hessen:
 kv_frankfurt:
   name: KV Frankfurt
   entity_level: KV
-  entity_id:
+  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_hessen) %>
 
 lv_bayern:
   name: LV Bayern
@@ -16,9 +16,9 @@ lv_bayern:
 kv_muenchen:
   name: KV Muenchen
   entity_level: KV
-  entity_id:
+  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>
 
 bzv_oberbayern:
   name: BZV Oberbayern
   entity_level: BZV
-  entity_id:
+  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -1,7 +1,48 @@
 require "test_helper"
 
 class EntityTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "parent_entity association returns the parent" do
+    kv = entities(:kv_frankfurt)
+    assert_equal entities(:lv_hessen), kv.parent_entity
+  end
+
+  test "sub_entities association returns children" do
+    lv = entities(:lv_bayern)
+    assert_includes lv.sub_entities, entities(:kv_muenchen)
+    assert_includes lv.sub_entities, entities(:bzv_oberbayern)
+  end
+
+  test "root entity has nil parent" do
+    lv = entities(:lv_hessen)
+    assert_nil lv.parent_entity
+  end
+
+  test "cannot reference self as parent" do
+    entity = entities(:lv_hessen)
+    entity.entity_id = entity.id
+    assert_not entity.valid?
+    assert_includes entity.errors[:entity_id], "kann nicht auf sich selbst verweisen"
+  end
+
+  test "cannot create circular reference" do
+    lv = entities(:lv_bayern)
+    kv = entities(:kv_muenchen)
+    # Make LV Bayern point to KV Muenchen (which already points to LV Bayern)
+    lv.entity_id = kv.id
+    assert_not lv.valid?
+    assert_includes lv.errors[:entity_id], "würde einen Zirkelbezug erzeugen"
+  end
+
+  test "valid parent reference is accepted" do
+    entity = Entity.new(name: "KV Test", entity_level: "KV", entity_id: entities(:lv_hessen).id)
+    assert entity.valid?
+  end
+
+  test "deleting parent nullifies children" do
+    parent = Entity.create!(name: "Parent Test", entity_level: "LV")
+    child = Entity.create!(name: "Child Test", entity_level: "KV", entity_id: parent.id)
+    parent.destroy!
+    child.reload
+    assert_nil child.entity_id
+  end
 end


### PR DESCRIPTION
## Summary
- Add `belongs_to :parent_entity` and `has_many :sub_entities` associations to `Entity`, replacing manual `Entity.find_by` lookups in views
- Add DB foreign key constraint and index on `entity_id`, plus validations preventing self-reference and circular references
- Add `parent_entity_name` field to JSON API responses, eager loading in controller, and 7 model tests for hierarchy behavior

## Test plan
- [x] `bin/rails db:migrate` runs cleanly
- [x] `bin/rails test` — all 126 tests pass
- [x] `bin/rails test test/models/entity_test.rb` — 7 new hierarchy tests pass
- [ ] Manual: create/edit entity in web UI, verify parent dropdown and display work
- [ ] Manual: verify `GET /entities.json` returns `parent_entity_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)