### PR TITLE
Rename entity_id to parent_entity_id and fix parent dropdown

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -66,6 +66,6 @@ class EntitiesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def entity_params
-      params.expect(entity: [ :name, :entity_level, :entity_id ])
+      params.expect(entity: [ :name, :entity_level, :parent_entity_id ])
     end
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,6 +1,6 @@
 class Entity < ApplicationRecord
-  belongs_to :parent_entity, class_name: "Entity", optional: true, foreign_key: :entity_id
-  has_many :sub_entities, class_name: "Entity", foreign_key: :entity_id, dependent: :nullify
+  belongs_to :parent_entity, class_name: "Entity", optional: true
+  has_many :sub_entities, class_name: "Entity", foreign_key: :parent_entity_id, dependent: :nullify
 
   has_many :tasks
 
@@ -23,20 +23,20 @@ class Entity < ApplicationRecord
   private
 
   def parent_is_not_self
-    errors.add(:entity_id, "kann nicht auf sich selbst verweisen") if entity_id.present? && entity_id == id
+    errors.add(:parent_entity_id, "kann nicht auf sich selbst verweisen") if parent_entity_id.present? && parent_entity_id == id
   end
 
   def parent_is_not_descendant
-    return if entity_id.blank?
-    ancestor = Entity.find_by(id: entity_id)
+    return if parent_entity_id.blank?
+    ancestor = Entity.find_by(id: parent_entity_id)
     visited = Set.new([ id ])
     while ancestor
       if visited.include?(ancestor.id)
-        errors.add(:entity_id, "würde einen Zirkelbezug erzeugen")
+        errors.add(:parent_entity_id, "würde einen Zirkelbezug erzeugen")
         break
       end
       visited << ancestor.id
-      ancestor = Entity.find_by(id: ancestor.entity_id)
+      ancestor = Entity.find_by(id: ancestor.parent_entity_id)
     end
   end
 end

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -7,10 +7,10 @@
       <div class="detail-value"><%= entity.entity_level_label || "Keine" %></div>
     </div>
 
-    <% if entity.entity_id.present? %>
+    <% if entity.parent_entity_id.present? %>
       <div class="detail-item">
         <div class="detail-label">Übergeordnete Gliederung</div>
-        <div class="detail-value"><%= entity.parent_entity&.name || entity.entity_id %></div>
+        <div class="detail-value"><%= entity.parent_entity&.name || entity.parent_entity_id %></div>
       </div>
     <% end %>
   </div>

--- a/app/views/entities/_entity.json.jbuilder
+++ b/app/views/entities/_entity.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! entity, :id, :name, :entity_level, :entity_id, :created_at, :updated_at
+json.extract! entity, :id, :name, :entity_level, :parent_entity_id, :created_at, :updated_at
 json.parent_entity_name entity.parent_entity&.name
 json.url entity_url(entity, format: :json)

--- a/app/views/entities/_form.html.erb
+++ b/app/views/entities/_form.html.erb
@@ -21,8 +21,8 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :entity_id, "Übergeordnete Gliederung" %>
-    <%= form.collection_select(:entity_id, Entity.where.not(id: entity.id), :id, :name, prompt: "Keine (oberste Ebene)", include_blank: false) %>
+    <%= form.label :parent_entity_id, "Übergeordnete Gliederung" %>
+    <%= form.collection_select(:parent_entity_id, Entity.where.not(id: entity.id), :id, :name, { include_blank: "Keine (oberste Ebene)" }) %>
   </div>
 
   <div class="btn-group">

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -272,7 +272,7 @@ grant_type=client_credentials
   "entity": {
     "name":         "string (required)",
     "entity_level": "string (one of: LV, BZV, KV)",
-    "entity_id":    "integer (optional, parent entity foreign key)"
+    "parent_entity_id": "integer (optional, parent entity foreign key)"
   }
 }</code></pre>
 
@@ -293,7 +293,7 @@ grant_type=client_credentials
   "id": 1,
   "name": "Piratenpartei Bayern",
   "entity_level": "LV",
-  "entity_id": null,
+  "parent_entity_id": null,
   "created_at": "2025-01-01T00:00:00.000Z",
   "updated_at": "2025-01-01T00:00:00.000Z",
   "parent_entity_name": null,

--- a/db/migrate/20260319200001_add_entity_parent_foreign_key.rb
+++ b/db/migrate/20260319200001_add_entity_parent_foreign_key.rb
@@ -1,6 +1,0 @@
-class AddEntityParentForeignKey < ActiveRecord::Migration[8.1]
-  def change
-    add_index :entities, :entity_id
-    add_foreign_key :entities, :entities, column: :entity_id
-  end
-end

--- a/db/migrate/20260319200002_rename_entity_id_and_add_foreign_key.rb
+++ b/db/migrate/20260319200002_rename_entity_id_and_add_foreign_key.rb
@@ -1,0 +1,7 @@
+class RenameEntityIdAndAddForeignKey < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :entities, :entity_id, :parent_entity_id
+    add_index :entities, :parent_entity_id
+    add_foreign_key :entities, :entities, column: :parent_entity_id
+  end
+end

--- a/db/migrate/20260319200002_rename_entity_id_to_parent_entity_id.rb
+++ b/db/migrate/20260319200002_rename_entity_id_to_parent_entity_id.rb
@@ -1,5 +1,0 @@
-class RenameEntityIdToParentEntityId < ActiveRecord::Migration[8.1]
-  def change
-    rename_column :entities, :entity_id, :parent_entity_id
-  end
-end

--- a/db/migrate/20260319200002_rename_entity_id_to_parent_entity_id.rb
+++ b/db/migrate/20260319200002_rename_entity_id_to_parent_entity_id.rb
@@ -1,0 +1,5 @@
+class RenameEntityIdToParentEntityId < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :entities, :entity_id, :parent_entity_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_19_200001) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_19_200002) do
   create_table "admin_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "reason"
@@ -54,9 +54,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_19_200001) do
 
   create_table "entities", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "entity_id"
     t.string "entity_level"
     t.string "name"
+    t.integer "parent_entity_id"
     t.datetime "updated_at", null: false
   end
 

--- a/docs/API_OVERVIEW.md
+++ b/docs/API_OVERVIEW.md
@@ -247,7 +247,7 @@ An entity represents an organizational unit (e.g. Landesverband, Bezirksverband,
   "entity": {
     "name": "string",
     "entity_level": "string (one of: LV, BZV, KV)",
-    "entity_id": "integer (optional, self-referencing parent entity)"
+    "parent_entity_id": "integer (optional, parent entity foreign key)"
   }
 }
 ```
@@ -261,7 +261,7 @@ An entity represents an organizational unit (e.g. Landesverband, Bezirksverband,
   "id": 1,
   "name": "KV Frankfurt",
   "entity_level": "KV",
-  "entity_id": 2,
+  "parent_entity_id": 2,
   "created_at": "2025-04-04T14:07:33.000Z",
   "updated_at": "2025-04-04T14:07:33.000Z",
   "parent_entity_name": "LV Hessen",
@@ -404,7 +404,7 @@ Comments are nested under tasks. Each comment belongs to a task.
 | id | integer | primary key, auto-increment |
 | name | string | |
 | entity_level | string | one of: LV (Landesverband), BZV (Bezirksverband), KV (Kreisverband) |
-| entity_id | integer | self-referencing parent entity |
+| parent_entity_id | integer | foreign key to parent entity |
 | created_at | datetime | not null |
 | updated_at | datetime | not null |
 
@@ -447,7 +447,7 @@ The `badge` count reflects the recipient's unread message count.
 
 ## Notes
 
-- The `entity_id` field on the entities table is a self-referencing foreign key for hierarchical organization (e.g. a Kreisverband belongs to a Landesverband).
+- The `parent_entity_id` field on the entities table is a self-referencing foreign key for hierarchical organization (e.g. a Kreisverband belongs to a Landesverband).
 - The `entity_level` field on entities indicates the organizational level (LV, BZV, KV).
 - All JSON responses from `/tasks`, `/entities`, `/categories`, `/comments` include a `url` field with the resource's canonical URL.
 - The root path (`/`) maps to `tasks#index`.

--- a/test/controllers/entities_controller_test.rb
+++ b/test/controllers/entities_controller_test.rb
@@ -36,7 +36,7 @@ class EntitiesControllerTest < ActionDispatch::IntegrationTest
   test "admin should create entity" do
     sign_in users(:admin_pirat)
     assert_difference("Entity.count") do
-      post entities_url, params: { entity: { entity_level: @entity.entity_level, entity_id: @entity.entity_id, name: @entity.name } }
+      post entities_url, params: { entity: { entity_level: @entity.entity_level, parent_entity_id: @entity.parent_entity_id, name: @entity.name } }
     end
 
     assert_redirected_to entity_url(Entity.last)
@@ -45,7 +45,7 @@ class EntitiesControllerTest < ActionDispatch::IntegrationTest
   test "regular user should not create entity" do
     sign_in users(:pirat)
     assert_no_difference("Entity.count") do
-      post entities_url, params: { entity: { entity_level: @entity.entity_level, entity_id: @entity.entity_id, name: @entity.name } }
+      post entities_url, params: { entity: { entity_level: @entity.entity_level, parent_entity_id: @entity.parent_entity_id, name: @entity.name } }
     end
 
     assert_redirected_to root_path
@@ -65,7 +65,7 @@ class EntitiesControllerTest < ActionDispatch::IntegrationTest
 
   test "admin should update entity" do
     sign_in users(:admin_pirat)
-    patch entity_url(@entity), params: { entity: { entity_level: @entity.entity_level, entity_id: @entity.entity_id, name: @entity.name } }
+    patch entity_url(@entity), params: { entity: { entity_level: @entity.entity_level, parent_entity_id: @entity.parent_entity_id, name: @entity.name } }
     assert_redirected_to entity_url(@entity)
   end
 

--- a/test/fixtures/entities.yml
+++ b/test/fixtures/entities.yml
@@ -1,24 +1,24 @@
 lv_hessen:
   name: LV Hessen
   entity_level: LV
-  entity_id:
+  parent_entity_id:
 
 kv_frankfurt:
   name: KV Frankfurt
   entity_level: KV
-  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_hessen) %>
+  parent_entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_hessen) %>
 
 lv_bayern:
   name: LV Bayern
   entity_level: LV
-  entity_id:
+  parent_entity_id:
 
 kv_muenchen:
   name: KV Muenchen
   entity_level: KV
-  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>
+  parent_entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>
 
 bzv_oberbayern:
   name: BZV Oberbayern
   entity_level: BZV
-  entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>
+  parent_entity_id: <%= ActiveRecord::FixtureSet.identify(:lv_bayern) %>

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -19,30 +19,30 @@ class EntityTest < ActiveSupport::TestCase
 
   test "cannot reference self as parent" do
     entity = entities(:lv_hessen)
-    entity.entity_id = entity.id
+    entity.parent_entity_id = entity.id
     assert_not entity.valid?
-    assert_includes entity.errors[:entity_id], "kann nicht auf sich selbst verweisen"
+    assert_includes entity.errors[:parent_entity_id], "kann nicht auf sich selbst verweisen"
   end
 
   test "cannot create circular reference" do
     lv = entities(:lv_bayern)
     kv = entities(:kv_muenchen)
     # Make LV Bayern point to KV Muenchen (which already points to LV Bayern)
-    lv.entity_id = kv.id
+    lv.parent_entity_id = kv.id
     assert_not lv.valid?
-    assert_includes lv.errors[:entity_id], "würde einen Zirkelbezug erzeugen"
+    assert_includes lv.errors[:parent_entity_id], "würde einen Zirkelbezug erzeugen"
   end
 
   test "valid parent reference is accepted" do
-    entity = Entity.new(name: "KV Test", entity_level: "KV", entity_id: entities(:lv_hessen).id)
+    entity = Entity.new(name: "KV Test", entity_level: "KV", parent_entity_id: entities(:lv_hessen).id)
     assert entity.valid?
   end
 
   test "deleting parent nullifies children" do
     parent = Entity.create!(name: "Parent Test", entity_level: "LV")
-    child = Entity.create!(name: "Child Test", entity_level: "KV", entity_id: parent.id)
+    child = Entity.create!(name: "Child Test", entity_level: "KV", parent_entity_id: parent.id)
     parent.destroy!
     child.reload
-    assert_nil child.entity_id
+    assert_nil child.parent_entity_id
   end
 end


### PR DESCRIPTION
## Summary
- Rename `entity_id` → `parent_entity_id` on entities table for clarity (reflects "Übergeordnete Gliederung")
- Fix parent entity dropdown: use `include_blank` so "Keine (oberste Ebene)" is always selectable (was defaulting to first entity for BV)
- Add index and foreign key constraint on `parent_entity_id`
- Update all references across model, controller, views, fixtures, tests, and API docs

## Test plan
- [x] `bin/rails db:migrate` runs cleanly
- [x] `bin/rails test` — all 126 tests pass
- [ ] Manual: verify parent dropdown shows "Keine (oberste Ebene)" as default for new entities
- [ ] Manual: verify `GET /entities.json` returns `parent_entity_id` and `parent_entity_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)